### PR TITLE
Fix versions conflict in Python 2.7 and 3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 # python setuptools files
 *.egg-info
+dist/
 
 # python virtualenv
 env/
 
 # vim swap files
 *.swp
+
+# tox workdir
+.tox/

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 publish:
-	@python setup.py sdist register upload
+	@python setup.py sdist bdist_wheel register upload

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[wheel]
+[bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="ptipython",
-    version="1.0.0",
+    version="1.0.1.dev0",
     license="MIT",
 
     description="Metapackage to install ptpython and ipython.",
@@ -19,11 +19,18 @@ setup(
 
     url="https://github.com/timofurrer/ptipython-meta",
 
-    include_package_data=True,
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
 
     install_requires=[
-        "ptpython",
-        "ipython"
+        # Python 2.7
+        "ipython<6; python_version=='2.7'",
+        "ptpython<2; python_version=='2.7'",
+        # Python 3.4
+        "ipython<7; python_version=='3.4'",
+        "ptpython<2; python_version=='3.4'",
+        # Python 3.5+
+        "ipython; python_version>='3.5'",
+        "ptpython; python_version>='3.5'",
     ],
 
     keywords=[

--- a/test.py
+++ b/test.py
@@ -1,0 +1,54 @@
+import sys
+import platform
+import subprocess
+
+from pkg_resources import get_distribution, DistributionNotFound, Requirement
+
+
+PYTHON_VERSION = platform.python_version()[:3]
+IPYTHON_LATEST = '>=7.3.0'   # as of 2019-03-02
+PTPYTHON_LATEST = '>=2.0.4'   # as of 2019-03-02
+VERSIONS = {
+    'ipython': {
+        '2.7': '==5.8.0',
+        '3.4': '==6.5.0',
+        '3.5': IPYTHON_LATEST,
+        '3.6': IPYTHON_LATEST,
+        '3.7': IPYTHON_LATEST,
+    },
+    'ptpython': {
+        '2.7': '==0.41',
+        '3.4': '==0.41',
+        '3.5': PTPYTHON_LATEST,
+        '3.6': PTPYTHON_LATEST,
+        '3.7': PTPYTHON_LATEST,
+    },
+}
+
+
+def check_broken_requirements():
+    returncode = subprocess.call([sys.executable, '-m', 'pip', 'check'])
+    assert returncode == 0, 'Broken requirements found.'
+
+
+def check_installed_version(package):
+    try:
+        version = get_distribution(package).version
+    except DistributionNotFound:
+        raise AssertionError('{} package not installed.'.format(package))
+    specifier = VERSIONS[package][PYTHON_VERSION]
+    requirement = Requirement.parse(package + specifier)
+    assert version in requirement, '{}: expected{}, actual=={}.'.format(
+        package, specifier, version)
+    print('{}: version check passed.'.format(package))
+
+
+def test():
+    check_broken_requirements()
+    check_installed_version('ipython')
+    check_installed_version('ptpython')
+    print('\nOK. All checks passed.\n')
+
+
+if __name__ == '__main__':
+    test()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27,py34,py35,py36,py37
+
+[testenv]
+commands = {envpython} test.py


### PR DESCRIPTION
As noted in [this issue](https://github.com/timofurrer/ptipython-meta/issues/1), the latest version of `ipython` available in Python 2.7 is not compatible with the latest version of `ptpython`. I've checked all supported Python versions (2.7, 3.4, 3.5, 3.6, 3.7 at the moment) and discovered that the same problem exists in Python 3.4.

This PR fixes the problem by declaring conditional requirements using `python_version` environment marker. I've also added some tests to check consistency of requirements.